### PR TITLE
Bump Three.js into r128

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var createLayout = require('layout-bmfont-text')
-var inherits = require('inherits')
 var createIndices = require('quad-indices')
 var buffer = require('three-buffer-vertex-data')
 var assign = require('object-assign')
@@ -7,28 +6,26 @@ var assign = require('object-assign')
 var vertices = require('./lib/vertices')
 var utils = require('./lib/utils')
 
-var Base = THREE.BufferGeometry
-
 module.exports = function createTextGeometry (opt) {
   return new TextGeometry(opt)
 }
 
-function TextGeometry (opt) {
-  Base.call(this)
+class TextGeometry extends THREE.BufferGeometry {
+  constructor (opt) {
+    super();
 
-  if (typeof opt === 'string') {
-    opt = { text: opt }
+    if (typeof opt === 'string') {
+      opt = { text: opt }
+    }
+
+    // use these as default values for any subsequent
+    // calls to update()
+    this._opt = assign({}, opt)
+
+    // also do an initial setup...
+    if (opt) this.update(opt)
   }
-
-  // use these as default values for any subsequent
-  // calls to update()
-  this._opt = assign({}, opt)
-
-  // also do an initial setup...
-  if (opt) this.update(opt)
 }
-
-inherits(TextGeometry, Base)
 
 TextGeometry.prototype.update = function (opt) {
   if (typeof opt === 'string') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7746,9 +7746,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.70.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.70.1.tgz",
-      "integrity": "sha1-RZ5eq/IkC9pY6kukEsFNCz5KJQ0=",
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
+      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
       "dev": true
     },
     "three-buffer-vertex-data": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "load-bmfont": "^1.0.0",
     "standard": "^5.4.1",
     "sun-tzu-quotes": "^1.0.0",
-    "three": "^0.70.0",
+    "three": "^0.128.0",
     "three-orbit-viewer": "^69.2.9",
     "three-vignette-background": "^1.0.2",
     "uglify-js": "^2.4.17"


### PR DESCRIPTION
This PR bumps Three.js into r128. We Hubs need this change to replace our Three.js fork with a newer one.